### PR TITLE
Attempt to fix WebpackOptionsValidationError: Invalid configuration o…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   target: 'node',
   module: {
-    loaders: [
+    rules: [
       { test: /\.ts(x?)$/, loader: 'ts-loader' },
     ],
   },


### PR DESCRIPTION
…bject. Webpack has been initialised using a configuration object that does not match the API schema.