### PR TITLE
Attempt to fix WebpackOptionsValidationError: Invalid configuration o…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,6 @@ custom:
         - aws-sdk
     excludeFiles: functions/test/**/*.spec.ts # Provide a glob for files to ignore
     series: true # run Webpack in series, useful for large projects. Defaults to false.
-    packager: 'npm' # Packager that will be used to package your external modules
 
 package:
     individually: true


### PR DESCRIPTION
…bject. Webpack has been initialised using a configuration object that does not match the API schema.