### PR TITLE
Attempt to fix WebpackOptionsValidationError: Invalid configuration o…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,12 +2,15 @@ service:
   name: aws-nodejs-typescript
 
 custom:
-  webpack: # https://www.serverless.com/plugins/serverless-webpack
+  # https://www.serverless.com/plugins/serverless-webpack
+  webpack:
     webpackConfig: 'webpack.config.js' # Name of webpack configuration file
-    includeModules: # true to enable auto-packing of external modules
+    includeModules:
       forceExclude:
-        - aws-sdk
+      - aws-sdk
     excludeFiles: functions/test/**/*.spec.ts # Provide a glob for files to ignore
+    series: true # run Webpack in series, useful for large projects. Defaults to false.
+    packager: 'npm' # Packager that will be used to package your external modules
 
 package:
     individually: true


### PR DESCRIPTION
…bject. Webpack has been initialised using a configuration object that does not match the API schema.