### PR TITLE
Attempt to fix WebpackOptionsValidationError: Invalid configuration o…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,16 +1,16 @@
 service:
   name: aws-nodejs-typescript
 
-custom:
-  # https://www.serverless.com/plugins/serverless-webpack
-  webpack:
-    webpackConfig: 'webpack.config.js' # Name of webpack configuration file
-    includeModules:
-      forceExclude:
-      - aws-sdk
-    excludeFiles: functions/test/**/*.spec.ts # Provide a glob for files to ignore
-    series: true # run Webpack in series, useful for large projects. Defaults to false.
-    packager: 'npm' # Packager that will be used to package your external modules
+# custom:
+#   # https://www.serverless.com/plugins/serverless-webpack
+#   webpack:
+#     webpackConfig: 'webpack.config.js' # Name of webpack configuration file
+#     includeModules:
+#       forceExclude:
+#         - aws-sdk
+#     excludeFiles: functions/test/**/*.spec.ts # Provide a glob for files to ignore
+#     series: true # run Webpack in series, useful for large projects. Defaults to false.
+#     packager: 'npm' # Packager that will be used to package your external modules
 
 package:
     individually: true


### PR DESCRIPTION
…bject. Webpack has been initialised using a configuration object that does not match the API schema.