### PR TITLE
Attempt to fix WebpackOptionsValidationError: Invalid configuration o…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ service:
 custom:
   # https://www.serverless.com/plugins/serverless-webpack
   webpack:
-    # webpackConfig: './webpack.config.js' # Name of webpack configuration file
+    webpackConfig: 'webpack.config.js' # Name of webpack configuration file
     includeModules:
       forceExclude:
         - aws-sdk

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,12 +41,12 @@ module.exports = {
     ],
   },
   plugins: [
-    new ForkTsCheckerWebpackPlugin({
-      eslint: {
-        options: {
-          cache: true
-        }
-      }
-    })
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: {
+    //     options: {
+    //       cache: true
+    //     }
+    //   }
+    // })
   ],
 };


### PR DESCRIPTION
…bject. Webpack has been initialised using a configuration object that does not match the API schema.