### PR TITLE
Attempts to fix Runtime dependency 'aws-lambda' found in devDependenc…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ custom:
     includeModules:
       forceExclude:
         - aws-sdk
+        - aws-lambda
     excludeFiles: functions/test/**/*.spec.ts # Provide a glob for files to ignore
     series: true # run Webpack in series, useful for large projects. Defaults to false.
     packager: 'npm' # Packager that will be used to package your external modules


### PR DESCRIPTION
…ies. Move it to dependencies or use forceExclude to explicitly exclude it.